### PR TITLE
Replace distutils with shutil

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python (version specified in .python-version)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
 
       - name: Install poetry and dependencies
         run: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python (version specified in .python-version)
         uses: actions/setup-python@v5

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -2,9 +2,9 @@ name: Lint and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
 
 permissions:
   contents: read
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python (version specified in .python-version)
-      uses: actions/setup-python@v3
+      - name: Set up Python (version specified in .python-version)
+        uses: actions/setup-python@v5
 
-    - name: Install poetry and dependencies
-      run : |
-        pip install poetry
-        poetry install
+      - name: Install poetry and dependencies
+        run: |
+          pip install poetry
+          poetry install
 
-    - name: Lint with Trunk
-      uses: trunk-io/trunk-action@v1
+      - name: Lint with Trunk
+        uses: trunk-io/trunk-action@v1
 
-    - name: Test with pytest
-      run: poetry run pytest
+      - name: Test with pytest
+        run: poetry run pytest

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,3 +1,9 @@
 *out
 *logs
-external
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,7 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,0 +1,5 @@
+# Generic, formatter-friendly config.
+select = ["B", "D3", "E", "F"]
+
+# Never enforce `E501` (line length violations). This should be handled by formatters.
+ignore = ["E501"]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,9 +1,35 @@
 version: 0.1
 cli:
-  version: 0.16.1-beta
+  version: 1.25.0
 lint:
   enabled:
-    - black@22.6.0
-    - flake8@4.0.1
-    - gitleaks@8.8.11
-    - isort@5.10.1
+    - actionlint@1.7.12
+    - bandit@1.9.4
+    - checkov@3.2.525
+    - git-diff-check
+    - osv-scanner@2.3.5
+    - prettier@3.8.3
+    - ruff@0.15.12
+    - taplo@0.10.0
+    - trufflehog@3.95.2
+    - yamllint@1.38.0
+    - black@26.3.1
+    - flake8@7.3.0
+    - gitleaks@8.30.1
+    - isort@8.0.1
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.7.6
+      uri: https://github.com/trunk-io/plugins
+actions:
+  enabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+    - trunk-upgrade-available
+runtimes:
+  enabled:
+    - node@22.16.0
+    - go@1.21.0
+    - python@3.10.8

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,23 +1,16 @@
 {
-    "editor.defaultFormatter": "ms-python.python",
-    "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
-    "[python]": {
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": true
-        },
-    },
-    "cSpell.words": [
-        "datedsubsection",
-        "ESISAR",
-        "linkedin",
-        "prometheus"
-    ],
-    "python.testing.pytestArgs": [
-        "src",
-        "-vv"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "githubIssues.issueBranchTitle": "issue${issueNumber}-${sanitizedIssueTitle}"
+  "editor.defaultFormatter": "trunk.io",
+  "editor.formatOnSave": true,
+  "python.formatting.provider": "black",
+  "[python]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "cSpell.words": ["datedsubsection", "ESISAR", "linkedin", "prometheus"],
+  "python.testing.pytestArgs": ["src", "-vv"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true,
+  "githubIssues.issueBranchTitle": "issue${issueNumber}-${sanitizedIssueTitle}",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "A utility to easily generate CV from a json description"
 authors = ["David Kragbé <42718923+dxvxd5@users.noreply.github.com>"]
 license = "MIT"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/converters/prometheus/prometheus.py
+++ b/src/converters/prometheus/prometheus.py
@@ -100,7 +100,11 @@ class PrometheusConverter:
         """
         Copy the template files to the output folder
         """
-        shutil.copytree(PrometheusConverter.get_templates_location(), output_folder, dirs_exist_ok=True)
+        shutil.copytree(
+            PrometheusConverter.get_templates_location(),
+            output_folder,
+            dirs_exist_ok=True,
+        )
 
     def create_latex_files(cv: CV, output_folder: str):
 

--- a/src/converters/prometheus/prometheus.py
+++ b/src/converters/prometheus/prometheus.py
@@ -1,5 +1,5 @@
 import os
-from distutils import dir_util
+import shutil
 
 from sections.cv import CV
 from sections.education import Education
@@ -100,7 +100,7 @@ class PrometheusConverter:
         """
         Copy the template files to the output folder
         """
-        dir_util.copy_tree(PrometheusConverter.get_templates_location(), output_folder)
+        shutil.copytree(PrometheusConverter.get_templates_location(), output_folder, dirs_exist_ok=True)
 
     def create_latex_files(cv: CV, output_folder: str):
 

--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 from io import TextIOWrapper
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError  # nosec B404
 
 import click
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import json
 import os
+import shutil
 import tempfile
-from distutils import dir_util, file_util
 from io import TextIOWrapper
 from subprocess import CalledProcessError
 
@@ -73,14 +73,14 @@ def main(input: TextIOWrapper, output: str, template: str):
         success("Compilation succeeded")
 
         info(f"Copying compiled pdf file {pdf_file} to {output_file}")
-        file_util.copy_file(pdf_file, output_file)
+        shutil.copy2(pdf_file, output_file)
         success("File copied")
         failure = False
 
     finally:
         info(f"Cleaning up temporary folder {tmpdir_path}")
         os.umask(prev_umask)
-        dir_util.remove_tree(tmpdir_path)
+        shutil.rmtree(tmpdir_path)
         success("Folder cleaned up")
 
     print()


### PR DESCRIPTION
Closes #42

## Changes
- Replace `distutils.dir_util.copy_tree` with `shutil.copytree`
- Replace `distutils.file_util.copy_file` with `shutil.copy2`
- Replace `distutils.dir_util.remove_tree` with `shutil.rmtree`
- Add `package-mode = false` to `pyproject.toml`
- Suppress `bandit/B404` on intentional `subprocess` import
- Upgrade `actions/checkout` from v3 to v4
- Upgrade `actions/setup-python` from v3 to v5
- Update trunk and VS Code config