### PR TITLE
Add type annotations across utils, converters, and tests

### DIFF
--- a/src/converters/prometheus/prometheus.py
+++ b/src/converters/prometheus/prometheus.py
@@ -20,12 +20,12 @@ class PrometheusConverter:
     NO_PERIOD = ""
 
     @staticmethod
-    def build_datedsubsection_cmd(*args) -> str:
-        return Latex.build_command("datedsubsection", args)
+    def build_datedsubsection_cmd(*args: str) -> str:
+        return Latex.build_command("datedsubsection", list(args))
 
     @staticmethod
-    def build_undatedsubsection_cmd(*args) -> str:
-        return Latex.build_command("undatedsubsection", args)
+    def build_undatedsubsection_cmd(*args: str) -> str:
+        return Latex.build_command("undatedsubsection", list(args))
 
     @staticmethod
     def convert_education(education: Education) -> str:

--- a/src/tests/utils/json_test.py
+++ b/src/tests/utils/json_test.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 import pytest
 
 from utils.json import check_dict
 
 
 @pytest.fixture
-def complete_education():
+def complete_education() -> dict[str, Any]:
     return {
         "startDate": 2018,
         "endDate": 2022,
@@ -17,7 +19,7 @@ def complete_education():
 
 
 @pytest.fixture
-def imcomplete_education():
+def imcomplete_education() -> dict[str, Any]:
     return {
         "startDate": 2018,
         "endDate": 2022,
@@ -27,7 +29,7 @@ def imcomplete_education():
 
 
 @pytest.fixture
-def expected_education_fields():
+def expected_education_fields() -> list[str]:
     return [
         "startDate",
         "endDate",
@@ -39,10 +41,14 @@ def expected_education_fields():
     ]
 
 
-def test_check_dict_complete(expected_education_fields, complete_education):
+def test_check_dict_complete(
+    expected_education_fields: list[str], complete_education: dict[str, Any]
+):
     assert check_dict(expected_education_fields, complete_education)
 
 
-def test_check_dict_imcomplete(expected_education_fields, imcomplete_education):
+def test_check_dict_imcomplete(
+    expected_education_fields: list[str], imcomplete_education: dict[str, Any]
+):
     with pytest.raises(ValueError):
         check_dict(expected_education_fields, imcomplete_education)

--- a/src/tests/utils/latex_test.py
+++ b/src/tests/utils/latex_test.py
@@ -4,21 +4,21 @@ from utils.latex import Latex
 
 
 @pytest.mark.parametrize("raw_item, latex_item", [("", ""), ("item1", "\\item item1")])
-def test_item(raw_item, latex_item):
+def test_item(raw_item: str, latex_item: str):
     assert Latex.item(raw_item) == latex_item
 
 
 @pytest.mark.parametrize(
     "block_name, begin_statement", [("", ""), ("itemize", "\\begin{itemize}")]
 )
-def test_begin(block_name, begin_statement):
+def test_begin(block_name: str, begin_statement: str):
     assert Latex.begin(block_name) == begin_statement
 
 
 @pytest.mark.parametrize(
     "block_name, end_statement", [("", ""), ("itemize", "\\end{itemize}")]
 )
-def test_end(block_name, end_statement):
+def test_end(block_name: str, end_statement: str):
     assert Latex.end(block_name) == end_statement
 
 
@@ -26,7 +26,7 @@ def test_end(block_name, end_statement):
     "items, latex_items",
     [(["item1", "item2"], "\\item item1\n\\item item2"), ([], ""), (["", ""], "")],
 )
-def test_to_itemize(items, latex_items):
+def test_to_itemize(items: list[str], latex_items: str):
     assert Latex.to_itemize(items) == latex_items
 
 
@@ -37,7 +37,7 @@ def test_build_itemize_block():
 
 
 @pytest.mark.parametrize("text, bold_text", [("", ""), ("text", "\\textbf{text}")])
-def test_bold(text, bold_text):
+def test_bold(text: str, bold_text: str):
     assert Latex.bold(text) == bold_text
 
 
@@ -50,7 +50,7 @@ def test_bold(text, bold_text):
         (["arg1", "arg2"], "{arg1}\n{arg2}"),
     ],
 )
-def test_to_command_args(arguments, latex_arguments):
+def test_to_command_args(arguments: list[str], latex_arguments: str):
     assert Latex.to_command_args(arguments) == latex_arguments
 
 
@@ -71,7 +71,7 @@ def test_to_dot_separated_items():
     "items, dot_separated_items",
     [(["item1", "", "item2", ""], "item1 $ \\cdot $ item2"), ([], ""), (["", ""], "")],
 )
-def test_to_dot_separated_items2(items, dot_separated_items):
+def test_to_dot_separated_items2(items: list[str], dot_separated_items: str):
     assert Latex.to_dot_separated_items(items) == dot_separated_items
 
 
@@ -86,6 +86,6 @@ def test_link():
 @pytest.mark.parametrize(
     "url, title", [("", "title"), ("http://example.com", ""), ("", "")]
 )
-def test_link_with_empty_params(url, title):
+def test_link_with_empty_params(url: str, title: str):
     with pytest.raises(ValueError):
         Latex.link(url, title)

--- a/src/utils/converters.py
+++ b/src/utils/converters.py
@@ -1,5 +1,7 @@
-from typing import Callable, List
+from typing import Callable, Sequence, TypeVar
+
+T = TypeVar("T")
 
 
-def convert_several(converter_fn: Callable[[object], str], items: List[object]):
+def convert_several(converter_fn: Callable[[T], str], items: Sequence[T]) -> str:
     return "\n".join(map(converter_fn, items))

--- a/src/utils/json.py
+++ b/src/utils/json.py
@@ -1,12 +1,13 @@
 import json
+from typing import Any
 
 
-def load_json(file_path):
+def load_json(file_path: str) -> Any:
     with open(file_path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
-def check_dict(fields, dict_):
+def check_dict(fields: list[str], dict_: dict[str, Any]) -> bool:
 
     for field in fields:
         if field not in dict_ or dict_[field] is None:

--- a/src/utils/path.py
+++ b/src/utils/path.py
@@ -1,7 +1,7 @@
 import os
 
 
-def change_extension(path, new_extension):
+def change_extension(path: str, new_extension: str) -> str:
     """
     Change the extension of the given path to the given new extension
     """


### PR DESCRIPTION
Fixes Pylance type errors in `json.py`, `converters.py`, `prometheus.py`, `path.py`, `latex_test.py`, and `json_test.py`.