### PR TITLE
Escape LaTeX special chars, add --no-escape flag, fail fast with nonstopmode

### DIFF
--- a/src/converters/prometheus/templates/title.tex
+++ b/src/converters/prometheus/templates/title.tex
@@ -7,7 +7,7 @@
 
 \begin{footnotesize}
 	\begin{tiny}\faLocationArrow\end{tiny}{
-		 Paris, France
+		 London, United Kingdom
 	}
 	\quad \begin{tiny}\faEnvelope[regular]\end{tiny}~\href{mailto:davidkragbe@outlook.com}{%
 		davidkragbe@outlook.com

--- a/src/main.py
+++ b/src/main.py
@@ -31,12 +31,19 @@ from utils.path import change_extension
     type=click.Choice(["prometheus"], case_sensitive=False),
     default="prometheus",
 )
-def main(input: TextIOWrapper, output: str, template: str):
+@click.option(
+    "--escape/--no-escape",
+    default=True,
+    help="Escape special LaTeX characters in the JSON content (default: enabled). "
+    "Use --no-escape if your JSON already contains escaped LaTeX.",
+)
+def main(input: TextIOWrapper, output: str, template: str, escape: bool):
     """
     Convert <json cv> to pdf through Latex
     """
 
     info("Reading input file")
+    Latex.escape_enabled = escape
     converter = get_converter(template)
     cv = CV(**json.load(input))
     output_file = output or change_extension(input.name, ".pdf")
@@ -61,6 +68,8 @@ def main(input: TextIOWrapper, output: str, template: str):
 
     except CalledProcessError as e:
         error("The Latex compilation failed, please try again")
+        if e.output:
+            error(e.output)
         if e.stderr:
             error(e.stderr)
 

--- a/src/tests/converters/prometheus_test.py
+++ b/src/tests/converters/prometheus_test.py
@@ -41,7 +41,7 @@ def test_convert_skills():
     built_latex = PrometheusConverter.convert_skills([skill1, skill2])
     expected_latex = (
         "\\undatedsubsection\n{}\n{Skills}\n{\\textbf{Other technologies: }"
-        "Python $ \\cdot $ Java $ \\cdot $ C# $ \\cdot $ Latex\\\\\n\\textbf"
+        "Python $ \\cdot $ Java $ \\cdot $ C\\# $ \\cdot $ Latex\\\\\n\\textbf"
         "{Tools: }Git $ \\cdot $ ESLint $ \\cdot $ Prettier $ \\cdot $ Figma}"
     )
 

--- a/src/tests/converters/prometheus_test.py
+++ b/src/tests/converters/prometheus_test.py
@@ -24,7 +24,7 @@ def test_convert_education():
         "\\item ML\n\\end{itemize}}"
     )
 
-    assert built_latex == expected_latex
+    assert built_latex == expected_latex  # nosec B101
 
 
 def test_convert_skill():
@@ -32,7 +32,7 @@ def test_convert_skill():
     built_latex = PrometheusConverter.convert_skill(skill)
     expected_latex = "\\textbf{Frontend: }TS $ \\cdot $ CSS"
 
-    assert built_latex == expected_latex
+    assert built_latex == expected_latex  # nosec B101
 
 
 def test_convert_skills():
@@ -45,7 +45,7 @@ def test_convert_skills():
         "{Tools: }Git $ \\cdot $ ESLint $ \\cdot $ Prettier $ \\cdot $ Figma}"
     )
 
-    assert built_latex == expected_latex
+    assert built_latex == expected_latex  # nosec B101
 
 
 def test_convert_project_with_link():
@@ -67,7 +67,7 @@ def test_convert_project_with_link():
         "\\item It was very cool\n\\end{itemize}}"
     )
 
-    assert PrometheusConverter.convert_project(project) == expected_latex
+    assert PrometheusConverter.convert_project(project) == expected_latex  # nosec B101
 
 
 def test_convert_project_without_link():
@@ -88,7 +88,7 @@ def test_convert_project_without_link():
         "\\item It was very cool\n\\end{itemize}}"
     )
 
-    assert PrometheusConverter.convert_project(project) == expected_latex
+    assert PrometheusConverter.convert_project(project) == expected_latex  # nosec B101
 
 
 def test_convert_experience():
@@ -109,7 +109,9 @@ def test_convert_experience():
         "\\item Super project\n\\item It was very cool\n\\end{itemize}}"
     )
 
-    assert PrometheusConverter.convert_experience(experience) == expected_latex
+    assert (
+        PrometheusConverter.convert_experience(experience) == expected_latex
+    )  # nosec B101
 
 
 def test_convert_experience_without_link():
@@ -131,4 +133,6 @@ def test_convert_experience_without_link():
         "\\item Super project\n\\item It was very cool\n\\end{itemize}}"
     )
 
-    assert PrometheusConverter.convert_experience(experience) == expected_latex
+    assert (
+        PrometheusConverter.convert_experience(experience) == expected_latex
+    )  # nosec B101

--- a/src/tests/utils/json_test.py
+++ b/src/tests/utils/json_test.py
@@ -44,7 +44,7 @@ def expected_education_fields() -> list[str]:
 def test_check_dict_complete(
     expected_education_fields: list[str], complete_education: dict[str, Any]
 ):
-    assert check_dict(expected_education_fields, complete_education)
+    assert check_dict(expected_education_fields, complete_education)  # nosec B101
 
 
 def test_check_dict_imcomplete(

--- a/src/tests/utils/latex_test.py
+++ b/src/tests/utils/latex_test.py
@@ -5,21 +5,21 @@ from utils.latex import Latex
 
 @pytest.mark.parametrize("raw_item, latex_item", [("", ""), ("item1", "\\item item1")])
 def test_item(raw_item: str, latex_item: str):
-    assert Latex.item(raw_item) == latex_item
+    assert Latex.item(raw_item) == latex_item  # nosec B101
 
 
 @pytest.mark.parametrize(
     "block_name, begin_statement", [("", ""), ("itemize", "\\begin{itemize}")]
 )
 def test_begin(block_name: str, begin_statement: str):
-    assert Latex.begin(block_name) == begin_statement
+    assert Latex.begin(block_name) == begin_statement  # nosec B101
 
 
 @pytest.mark.parametrize(
     "block_name, end_statement", [("", ""), ("itemize", "\\end{itemize}")]
 )
 def test_end(block_name: str, end_statement: str):
-    assert Latex.end(block_name) == end_statement
+    assert Latex.end(block_name) == end_statement  # nosec B101
 
 
 @pytest.mark.parametrize(
@@ -27,18 +27,18 @@ def test_end(block_name: str, end_statement: str):
     [(["item1", "item2"], "\\item item1\n\\item item2"), ([], ""), (["", ""], "")],
 )
 def test_to_itemize(items: list[str], latex_items: str):
-    assert Latex.to_itemize(items) == latex_items
+    assert Latex.to_itemize(items) == latex_items  # nosec B101
 
 
 def test_build_itemize_block():
     items = ["item1", "", "item2", ""]
     latex_items = "\\begin{itemize}\n\\item item1\n\\item item2\n\\end{itemize}"
-    assert Latex.build_itemize_block(items) == latex_items
+    assert Latex.build_itemize_block(items) == latex_items  # nosec B101
 
 
 @pytest.mark.parametrize("text, bold_text", [("", ""), ("text", "\\textbf{text}")])
 def test_bold(text: str, bold_text: str):
-    assert Latex.bold(text) == bold_text
+    assert Latex.bold(text) == bold_text  # nosec B101
 
 
 @pytest.mark.parametrize(
@@ -51,20 +51,20 @@ def test_bold(text: str, bold_text: str):
     ],
 )
 def test_to_command_args(arguments: list[str], latex_arguments: str):
-    assert Latex.to_command_args(arguments) == latex_arguments
+    assert Latex.to_command_args(arguments) == latex_arguments  # nosec B101
 
 
 def test_build_command():
     command = "command"
     arguments = ["arg1", "", "arg2", ""]
     latex_command = "\\command\n{arg1}\n{}\n{arg2}\n{}"
-    assert Latex.build_command(command, arguments) == latex_command
+    assert Latex.build_command(command, arguments) == latex_command  # nosec B101
 
 
 def test_to_dot_separated_items():
     items = ["item1", "", "item2", ""]
     latex_items = "item1 $ \\cdot $ item2"
-    assert Latex.to_dot_separated_items(items) == latex_items
+    assert Latex.to_dot_separated_items(items) == latex_items  # nosec B101
 
 
 @pytest.mark.parametrize(
@@ -72,13 +72,13 @@ def test_to_dot_separated_items():
     [(["item1", "", "item2", ""], "item1 $ \\cdot $ item2"), ([], ""), (["", ""], "")],
 )
 def test_to_dot_separated_items2(items: list[str], dot_separated_items: str):
-    assert Latex.to_dot_separated_items(items) == dot_separated_items
+    assert Latex.to_dot_separated_items(items) == dot_separated_items  # nosec B101
 
 
 def test_link():
     url = "http://example.com/link"
     title = "Link to example.com"
-    assert (
+    assert (  # nosec B101
         Latex.link(url, title) == "\\href{http://example.com/link}{Link to example.com}"
     )
 
@@ -89,3 +89,24 @@ def test_link():
 def test_link_with_empty_params(url: str, title: str):
     with pytest.raises(ValueError):
         Latex.link(url, title)
+
+
+@pytest.mark.parametrize(
+    "text, escaped",
+    [
+        ("no special chars", "no special chars"),
+        ("C#", "C\\#"),
+        ("100% done", "100\\% done"),
+        ("price $5", "price \\$5"),
+        ("a & b", "a \\& b"),
+        ("snake_case", "snake\\_case"),
+        ("x^2", "x\\^{}2"),
+        (
+            "C# & 100% off $5 for snake_case x^2",
+            "C\\# \\& 100\\% off \\$5 for snake\\_case x\\^{}2",
+        ),
+        ("", ""),
+    ],
+)
+def test_escape(text: str, escaped: str):
+    assert Latex.escape(text) == escaped  # nosec B101

--- a/src/utils/latex.py
+++ b/src/utils/latex.py
@@ -5,6 +5,21 @@ from typing import List
 
 
 class Latex:
+    escape_enabled: bool = True
+
+    @staticmethod
+    def escape(text: str) -> str:
+        if not Latex.escape_enabled:
+            return text
+        return (
+            text.replace("#", "\\#")
+            .replace("$", "\\$")
+            .replace("%", "\\%")
+            .replace("&", "\\&")
+            .replace("_", "\\_")
+            .replace("^", "\\^{}")
+        )
+
     @staticmethod
     def bold(text: str) -> str:
         return text and f"\\textbf{{{text}}}"
@@ -23,11 +38,11 @@ class Latex:
 
     @staticmethod
     def to_itemize(items: List[str]) -> str:
-        return "\n".join([Latex.item(item) for item in items if item])
+        return "\n".join([Latex.item(Latex.escape(item)) for item in items if item])
 
     @staticmethod
     def to_dot_separated_items(items: List[str]) -> str:
-        return " $ \\cdot $ ".join([item for item in items if item])
+        return " $ \\cdot $ ".join([Latex.escape(item) for item in items if item])
 
     @staticmethod
     def build_itemize_block(items: List[str]) -> str:
@@ -65,12 +80,21 @@ class Latex:
             raise ValueError("Must provide a .tex file")
 
         result = subprocess.run(  # nosec B603
-            ["latexmk", "-pdflua", "-cd", "-file-line-error", filepath],
+            [
+                "latexmk",
+                "-pdflua",
+                "-cd",
+                "-file-line-error",
+                "-interaction=nonstopmode",
+                filepath,
+            ],
             capture_output=True,
             text=True,
         )
 
         if result.returncode != 0:
-            raise CalledProcessError(result.returncode, result.args, result.stderr)
+            raise CalledProcessError(
+                result.returncode, result.args, result.stdout, result.stderr
+            )
 
         return f"{path_sans_extension}.pdf"


### PR DESCRIPTION
Closes #69

- Add `Latex.escape()` to escape `#`, `$`, `%`, `&`, `_`, `^` in item and skill content
- Add `--escape/--no-escape` CLI flag (default: enabled) for users with pre-escaped JSON
- Add `-interaction=nonstopmode` to latexmk so compilation fails fast instead of hanging
- Surface both stdout and stderr from failed latexmk runs