### PR TITLE
Auto-discover converters via a registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Options:
 | Flag             | Description                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
 | `-o, --output`   | Path to the generated PDF. Defaults to the input path with a `.pdf` extension.                              |
-| `-t, --template` | Template to use. Currently only `prometheus`.                                                               |
+| `-t, --template` | Template to use. Defaults to `prometheus`. See [Adding a template](#adding-a-template).                     |
 | `--no-escape`    | Skip escaping LaTeX special characters in the input (use only if your JSON already contains escaped LaTeX). |
 
 ## JSON schema
@@ -88,6 +88,36 @@ Required: `startDate`, `endDate`, `city`, `country`, `context`, `title`, `descri
 ### `skills[]`
 
 Required: `area` (e.g. `"Languages"`), `skills` (list of strings).
+
+## Adding a template
+
+Templates are auto-discovered from `src/converters/`. To add one named `mytheme`:
+
+1. Create `src/converters/mytheme/` with your converter class and any LaTeX assets it needs (e.g. `templates/mytheme/main.tex`, `.cls` files).
+2. Implement a converter class. The only contract required by the CLI is a single method:
+
+   ```python
+   class MyThemeConverter:
+       @staticmethod
+       def generate_latex_files(cv: CV, output_folder: str) -> str:
+           """
+           Render `cv` into LaTeX files under `output_folder` and return the
+           absolute path of the main `.tex` file to compile.
+           """
+           ...
+   ```
+
+   `cv` is a [`CV`](src/sections/cv.py) instance exposing `user`, `education`, `experiences`, `projects`, `skills`. Use the [`Latex`](src/utils/latex.py) helpers (`escape`, `join`, `bold`, `link`, `build_command`, …) so escaping stays consistent — pass raw strings in and let the helpers escape display content. See [src/converters/prometheus/prometheus.py](src/converters/prometheus/prometheus.py) for a full example.
+
+3. Expose the converter in `src/converters/mytheme/__init__.py`:
+
+   ```python
+   from converters.mytheme.mytheme import MyThemeConverter
+
+   CONVERTER = MyThemeConverter
+   ```
+
+4. Run with `--template mytheme`. The CLI's `--template` choices are derived from the registry, so no other code changes are required.
 
 ## Tests
 

--- a/src/converters/__init__.py
+++ b/src/converters/__init__.py
@@ -1,0 +1,22 @@
+"""
+Converter registry.
+
+Each subpackage under ``converters/`` is treated as a template. To register a
+new template, create ``converters/<name>/__init__.py`` exposing a
+module-level ``CONVERTER`` attribute pointing at the converter class. The
+template will be picked up automatically by the CLI without any further code
+changes.
+"""
+
+import importlib
+import pkgutil
+
+CONVERTERS: dict[str, type] = {}
+
+for _module_info in pkgutil.iter_modules(__path__):
+    if not _module_info.ispkg:
+        continue
+    _module = importlib.import_module(f"{__name__}.{_module_info.name}")
+    _converter = getattr(_module, "CONVERTER", None)
+    if _converter is not None:
+        CONVERTERS[_module_info.name] = _converter

--- a/src/converters/prometheus/__init__.py
+++ b/src/converters/prometheus/__init__.py
@@ -1,0 +1,3 @@
+from converters.prometheus.prometheus import PrometheusConverter
+
+CONVERTER = PrometheusConverter

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from subprocess import CalledProcessError  # nosec B404
 
 import click
 
+from converters import CONVERTERS
 from sections.cv import CV
 from utils.cli import error, get_converter, info, success
 from utils.json import validate_cv
@@ -29,8 +30,9 @@ from utils.path import change_extension
 @click.option(
     "-t",
     "--template",
-    type=click.Choice(["prometheus"], case_sensitive=False),
+    type=click.Choice(sorted(CONVERTERS), case_sensitive=False),
     default="prometheus",
+    show_default=True,
 )
 @click.option(
     "--escape/--no-escape",

--- a/src/tests/utils/cli_test.py
+++ b/src/tests/utils/cli_test.py
@@ -1,0 +1,19 @@
+import pytest
+
+from converters import CONVERTERS
+from converters.prometheus.prometheus import PrometheusConverter
+from utils.cli import get_converter
+
+
+def test_registry_discovers_prometheus():
+    assert CONVERTERS["prometheus"] is PrometheusConverter  # nosec B101
+
+
+def test_get_converter_returns_registered_class():
+    assert get_converter("prometheus") is PrometheusConverter  # nosec B101
+
+
+def test_get_converter_raises_for_unknown_template():
+    with pytest.raises(ValueError) as exc:
+        get_converter("nope")
+    assert "nope" in str(exc.value)  # nosec B101

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -11,7 +11,7 @@ def get_converter(template: str):
     try:
         return CONVERTERS[template]
     except KeyError:
-        raise ValueError(f"Unknown template: {template}")
+        raise ValueError(f"Unknown template: {template}") from None
 
 
 def info(msg: str):

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -2,15 +2,15 @@ import enum
 
 import click
 
-from converters.prometheus.prometheus import PrometheusConverter
+from converters import CONVERTERS
 
 MSG_TYPE = enum.Enum("MSG_TYPE", "INFO SUCCESS ERROR")
 
 
 def get_converter(template: str):
-    if template == "prometheus":
-        return PrometheusConverter
-    else:
+    try:
+        return CONVERTERS[template]
+    except KeyError:
         raise ValueError(f"Unknown template: {template}")
 
 


### PR DESCRIPTION
Closes #75.

Templates are auto-discovered from `src/converters/` subpackages. Each subpackage's `__init__.py` exposes a `CONVERTER` attribute; `converters/__init__.py` walks the package and builds a `CONVERTERS` registry. The CLI's `--template` choices and `get_converter` both derive from it.

Default template stays hardcoded as `prometheus` — that's a UX choice, not a discovery concern.

Updates documentation too.