### PR TITLE
Make non-user sections optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ The input is validated against [src/schema/cv.schema.json](src/schema/cv.schema.
 ```jsonc
 {
   "user":        { ... },           // required
-  "education":   [ { ... }, ... ],  // required (may be empty)
-  "experiences": [ { ... }, ... ],  // required (may be empty)
-  "projects":    [ { ... }, ... ],  // required (may be empty)
-  "skills":      [ { ... }, ... ]   // required (may be empty)
+  "education":   [ { ... }, ... ],  // optional; omit or pass [] to hide the section
+  "experiences": [ { ... }, ... ],  // optional; omit or pass [] to hide the section
+  "projects":    [ { ... }, ... ],  // optional; omit or pass [] to hide the section
+  "skills":      [ { ... }, ... ]   // optional; omit or pass [] to hide the section
 }
 ```
+
+`user` is required, and at least one of `education`, `experiences` or `projects` must contain at least one entry. Any section that is omitted (or empty) is skipped entirely — no heading is rendered for it.
 
 See [examples/cv.example.json](examples/cv.example.json) for a complete, working example.
 

--- a/src/converters/prometheus/prometheus.py
+++ b/src/converters/prometheus/prometheus.py
@@ -21,6 +21,19 @@ class PrometheusConverter:
     NO_PERIOD = ""
     TITLE_VSPACE = "0.25em"
 
+    # (output file stem, section heading, CV attribute name, converter method name)
+    # Order matches the original main.tex layout.
+    LIST_SECTIONS = (
+        (
+            "experiences",
+            "Professional Experiences",
+            "experiences",
+            "convert_experience",
+        ),
+        ("projects", "Projects", "projects", "convert_project"),
+        ("education", "Education", "education", "convert_education"),
+    )
+
     @staticmethod
     def build_datedsubsection_cmd(*args: str) -> str:
         return Latex.build_command("datedsubsection", list(args))
@@ -181,21 +194,27 @@ class PrometheusConverter:
             main_tex = f.read()
         main_tex = main_tex.replace("__FULL_NAME__", Latex.escape(cv.user.full_name))
 
-        # Maps the name of the files to create to their content
+        # Title is always emitted (user is required).
         files_to_create = {
-            "main": main_tex,
             "title": PrometheusConverter.convert_user(cv.user),
-            "education": convert_several(
-                PrometheusConverter.convert_education, cv.education
-            ),
-            "experiences": convert_several(
-                PrometheusConverter.convert_experience, cv.experiences
-            ),
-            "projects": convert_several(
-                PrometheusConverter.convert_project, cv.projects
-            ),
-            "skills": PrometheusConverter.convert_skills(cv.skills),
         }
+
+        section_blocks: list[str] = []
+        for file_name, title, attr, converter_name in PrometheusConverter.LIST_SECTIONS:
+            items = getattr(cv, attr)
+            if not items:
+                continue
+            item_converter = getattr(PrometheusConverter, converter_name)
+            files_to_create[file_name] = convert_several(item_converter, items)
+            section_blocks.append(f"\\section{{{title}}}\n\\input{{{file_name}.tex}}")
+
+        if cv.skills:
+            files_to_create["skills"] = PrometheusConverter.convert_skills(cv.skills)
+            section_blocks.append("\\section{Skills}\n\\input{skills.tex}")
+
+        files_to_create["main"] = main_tex.replace(
+            "__SECTIONS__", "\n\n".join(section_blocks)
+        )
 
         for file_name, file_content in files_to_create.items():
             file_path = os.path.join(output_folder, f"{file_name}.tex")

--- a/src/converters/prometheus/templates/prometheus/main.tex
+++ b/src/converters/prometheus/templates/prometheus/main.tex
@@ -50,29 +50,6 @@
 \centering 
 \input{title.tex}
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%% Experiences %%%%%%%%%%%% 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% \vspace*{0.2cm}
-\section{Professional Experiences}
-\input{experiences.tex}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%% Projects %%%%%%%%%%%% 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Projects}
-\input{projects.tex}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%% Education %%%%%%%%%%%% 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Education}
-\input{education.tex}
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%%%%%%%%%%%% SKILLS %%%%%%%%%%%% 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\section{Skills}
-\input{skills.tex}
+__SECTIONS__
 
 \end{document}

--- a/src/schema/cv.schema.json
+++ b/src/schema/cv.schema.json
@@ -4,7 +4,21 @@
   "title": "CV",
   "type": "object",
   "additionalProperties": false,
-  "required": ["user", "education", "experiences", "projects", "skills"],
+  "required": ["user"],
+  "anyOf": [
+    {
+      "required": ["education"],
+      "properties": { "education": { "minItems": 1 } }
+    },
+    {
+      "required": ["experiences"],
+      "properties": { "experiences": { "minItems": 1 } }
+    },
+    {
+      "required": ["projects"],
+      "properties": { "projects": { "minItems": 1 } }
+    }
+  ],
   "properties": {
     "user": { "$ref": "#/$defs/user" },
     "education": {

--- a/src/sections/cv.py
+++ b/src/sections/cv.py
@@ -13,15 +13,17 @@ class CV:
         self.user: User = User(**kwargs["user"])
 
         self.education: List[Education] = [
-            Education(**edu) for edu in kwargs["education"]
+            Education(**edu) for edu in kwargs.get("education", [])
         ]
 
         self.experiences: List[Experience] = [
-            Experience(**experience) for experience in kwargs["experiences"]
+            Experience(**experience) for experience in kwargs.get("experiences", [])
         ]
 
-        self.skills: List[Skill] = [Skill(**skill) for skill in kwargs["skills"]]
+        self.skills: List[Skill] = [
+            Skill(**skill) for skill in kwargs.get("skills", [])
+        ]
 
         self.projects: List[Project] = [
-            Project(**project) for project in kwargs["projects"]
+            Project(**project) for project in kwargs.get("projects", [])
         ]

--- a/src/tests/converters/prometheus_test.py
+++ b/src/tests/converters/prometheus_test.py
@@ -297,3 +297,30 @@ def test_convert_experience_without_link_escapes_company_name():
     )
     result = PrometheusConverter.convert_experience(experience)
     assert r"{A \& B - X, Y}" in result  # nosec B101
+
+
+def test_create_latex_files_omits_section_blocks_for_empty_sections(tmp_path):
+    from sections.cv import CV
+
+    cv = CV(
+        user={
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "city": "London",
+            "country": "United Kingdom",
+            "email": "ada@example.com",
+        },
+        skills=[{"area": "Languages", "skills": ["Python"]}],
+    )
+    PrometheusConverter.create_latex_files(cv, str(tmp_path))
+
+    main_tex = (tmp_path / "main.tex").read_text()
+    assert r"\section{Skills}" in main_tex  # nosec B101
+    assert r"\input{skills.tex}" in main_tex  # nosec B101
+    for absent in ("Professional Experiences", "Projects", "Education"):
+        assert absent not in main_tex  # nosec B101
+
+    assert (tmp_path / "title.tex").exists()  # nosec B101
+    assert (tmp_path / "skills.tex").exists()  # nosec B101
+    for absent_file in ("experiences.tex", "projects.tex", "education.tex"):
+        assert not (tmp_path / absent_file).exists()  # nosec B101

--- a/src/tests/sections/cv_test.py
+++ b/src/tests/sections/cv_test.py
@@ -1,0 +1,27 @@
+from sections.cv import CV
+
+MINIMAL_USER = {
+    "firstName": "Ada",
+    "lastName": "Lovelace",
+    "city": "London",
+    "country": "United Kingdom",
+    "email": "ada@example.com",
+}
+
+
+def test_cv_defaults_missing_sections_to_empty_lists():
+    cv = CV(user=MINIMAL_USER)
+    assert cv.education == []  # nosec B101
+    assert cv.experiences == []  # nosec B101
+    assert cv.projects == []  # nosec B101
+    assert cv.skills == []  # nosec B101
+
+
+def test_cv_keeps_provided_sections():
+    cv = CV(
+        user=MINIMAL_USER,
+        skills=[{"area": "Languages", "skills": ["Python"]}],
+    )
+    assert cv.education == []  # nosec B101
+    assert len(cv.skills) == 1  # nosec B101
+    assert cv.skills[0].area == "Languages"  # nosec B101

--- a/src/tests/utils/json_test.py
+++ b/src/tests/utils/json_test.py
@@ -24,11 +24,45 @@ def test_validate_cv_accepts_example(valid_cv: dict[str, Any]):
     validate_cv(valid_cv)  # does not raise
 
 
-def test_validate_cv_rejects_missing_top_level_section(valid_cv: dict[str, Any]):
-    del valid_cv["education"]
+def test_validate_cv_rejects_missing_user(valid_cv: dict[str, Any]):
+    del valid_cv["user"]
     with pytest.raises(ValueError) as exc:
         validate_cv(valid_cv)
-    assert "education" in str(exc.value)  # nosec B101
+    assert "user" in str(exc.value)  # nosec B101
+
+
+def test_validate_cv_skills_section_is_optional(valid_cv: dict[str, Any]):
+    valid_cv.pop("skills", None)
+    validate_cv(valid_cv)  # does not raise
+
+
+def test_validate_cv_requires_at_least_one_of_edu_exp_proj(
+    valid_cv: dict[str, Any],
+):
+    for section in ("education", "experiences", "projects"):
+        valid_cv.pop(section, None)
+    with pytest.raises(ValueError) as exc:
+        validate_cv(valid_cv)
+    msg = str(exc.value)
+    assert "education" in msg  # nosec B101
+    assert "experiences" in msg  # nosec B101
+    assert "projects" in msg  # nosec B101
+    assert "at least one" in msg  # nosec B101
+
+
+def test_validate_cv_accepts_only_one_of_edu_exp_proj(valid_cv: dict[str, Any]):
+    # Keep experiences only; drop the other two list sections.
+    for section in ("education", "projects"):
+        valid_cv.pop(section, None)
+    validate_cv(valid_cv)  # does not raise
+
+
+def test_validate_cv_rejects_only_empty_list_sections(valid_cv: dict[str, Any]):
+    valid_cv["education"] = []
+    valid_cv["experiences"] = []
+    valid_cv["projects"] = []
+    with pytest.raises(ValueError):
+        validate_cv(valid_cv)
 
 
 def test_validate_cv_rejects_missing_user_field(valid_cv: dict[str, Any]):

--- a/src/utils/json.py
+++ b/src/utils/json.py
@@ -38,6 +38,18 @@ def _format_error_path(error) -> str:
     return "".join(parts)
 
 
+def _format_error_message(error) -> str:
+    # The schema's top-level ``anyOf`` enforces "at least one non-empty list
+    # section among education/experiences/projects". The default jsonschema
+    # message dumps the entire input and says "not valid under any of the
+    # given schemas", which is unhelpful — rewrite it.
+    if error.validator == "anyOf" and not list(error.absolute_path):
+        return (
+            "provide at least one entry in 'education', " "'experiences' or 'projects'"
+        )
+    return error.message
+
+
 def validate_cv(data: Any) -> None:
     """Validate ``data`` against the CV JSON schema.
 
@@ -50,6 +62,7 @@ def validate_cv(data: Any) -> None:
     if not errors:
         return
     formatted = "\n".join(
-        f"  - {_format_error_path(error)}: {error.message}" for error in errors
+        f"  - {_format_error_path(error)}: {_format_error_message(error)}"
+        for error in errors
     )
     raise ValueError(f"Invalid CV JSON:\n{formatted}")

--- a/src/utils/json.py
+++ b/src/utils/json.py
@@ -40,13 +40,20 @@ def _format_error_path(error) -> str:
 
 def _format_error_message(error) -> str:
     # The schema's top-level ``anyOf`` enforces "at least one non-empty list
-    # section among education/experiences/projects". The default jsonschema
-    # message dumps the entire input and says "not valid under any of the
-    # given schemas", which is unhelpful — rewrite it.
+    # section among the configured fields". The default jsonschema message
+    # dumps the entire input and says "not valid under any of the given
+    # schemas", which is unhelpful — rewrite it using the schema itself so
+    # the message stays in sync if the rule changes.
     if error.validator == "anyOf" and not list(error.absolute_path):
-        return (
-            "provide at least one entry in 'education', " "'experiences' or 'projects'"
-        )
+        fields = [
+            name
+            for subschema in error.validator_value
+            for name in subschema.get("required", [])
+        ]
+        if fields:
+            quoted = ", ".join(f"'{name}'" for name in fields[:-1])
+            joined = f"{quoted} or '{fields[-1]}'" if quoted else f"'{fields[-1]}'"
+            return f"provide at least one entry in {joined}"
     return error.message
 
 


### PR DESCRIPTION
Closes #78.

Only `user` is required. Omitted/empty sections are skipped in the rendered PDF. A top-level `anyOf` rule still requires at least one entry across `education`/`experiences`/`projects`; its error message is rewritten to be actionable.